### PR TITLE
fix: Corregir errores de compilación y advertencias

### DIFF
--- a/Controllers/HomeController.cs
+++ b/Controllers/HomeController.cs
@@ -6,8 +6,9 @@ using System.Threading.Tasks;
 using Zenko.Services;
 using Zenko.Models;
 using System.Data;
-using System.Data.SqlClient;
+using Microsoft.Data.SqlClient;
 using System;
+using System.Linq;
 
 
 public class HomeController : Controller

--- a/Models/BD.cs
+++ b/Models/BD.cs
@@ -1,5 +1,5 @@
 using System;
-using System.Data.SqlClient;
+using Microsoft.Data.SqlClient;
 using Dapper;
 using Newtonsoft.Json;
 using Zenko.Models;

--- a/Models/ErrorViewModel.cs
+++ b/Models/ErrorViewModel.cs
@@ -1,3 +1,4 @@
+#nullable enable
 namespace ZenkoApp.Models;
 
 public class ErrorViewModel
@@ -6,3 +7,4 @@ public class ErrorViewModel
 
     public bool ShowRequestId => !string.IsNullOrEmpty(RequestId);
 }
+#nullable disable


### PR DESCRIPTION
He solucionado varios problemas que impedían que el proyecto se compilara y se ejecutara correctamente, y he abordado las advertencias de obsolescencia para modernizar el código.

Cambios:
- **Error de Compilación (CS1061):** He añadido `using System.Linq;` a `HomeController.cs` para resolver un error que impedía el uso del método `GroupBy`.
- **Advertencias de Obsolescencia:** He reemplazado el obsoleto `System.Data.SqlClient` por el moderno `Microsoft.Data.SqlClient` en todos los archivos relevantes (`HomeController.cs`, `Models/BD.cs`) para eliminar las advertencias de compilación.
- **Advertencia de Nulabilidad (CS8632):** He habilitado el contexto de anotaciones `nullable` en `ErrorViewModel.cs` para resolver la advertencia relacionada con los tipos de referencia que aceptan valores NULL.