### PR TITLE
fix: Añadir referencia de paquete para Microsoft.Data.SqlClient

### DIFF
--- a/ZenkoApp.csproj
+++ b/ZenkoApp.csproj
@@ -9,7 +9,7 @@
     <PackageReference Include="Dapper" Version="2.1.66" />
     <PackageReference Include="EPPlus" Version="6.0.3" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
-    <PackageReference Include="System.Data.SqlClient" Version="4.9.0" />
+    <PackageReference Include="Microsoft.Data.SqlClient" Version="5.2.0" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Se ha añadido la referencia de paquete `Microsoft.Data.SqlClient` al archivo .csproj y se ha eliminado la referencia al obsoleto `System.Data.SqlClient`.

Este cambio corrige los errores de compilación (CS0234 y CS0246) que surgieron después de migrar el código para usar el nuevo proveedor de datos de SQL Server. El proyecto ahora tiene la dependencia necesaria para encontrar los tipos `SqlConnection` y `SqlCommand` dentro del espacio de nombres `Microsoft.Data.SqlClient`.