### PR TITLE
fix: Resolver problema de confianza de certificado SSL de SQL Server

### DIFF
--- a/Models/BD.cs
+++ b/Models/BD.cs
@@ -8,7 +8,7 @@ using System.Linq;
 
 public static class BD
 {
-    private static string connectionString = "Server=localhost;Database=Zenko;Trusted_Connection=True;";
+    private static string connectionString = "Server=localhost;Database=Zenko;Trusted_Connection=True;TrustServerCertificate=True;";
 
   public static void InsertarInsumo(Insumo insumo)
 {

--- a/appsettings.json
+++ b/appsettings.json
@@ -1,6 +1,6 @@
 {
   "ConnectionStrings": {
-    "DefaultConnection": "Server=localhost;Database=Zenko;Trusted_Connection=True;"
+    "DefaultConnection": "Server=localhost;Database=Zenko;Trusted_Connection=True;TrustServerCertificate=True;"
   },
   "Logging": {
     "LogLevel": {


### PR DESCRIPTION
Se ha añadido `TrustServerCertificate=True;` a las cadenas de conexión en `appsettings.json` y en la clase estática `Models/BD.cs`.

Este cambio es necesario para solucionar una excepción de `SqlException` que ocurre al usar la biblioteca `Microsoft.Data.SqlClient`. Por defecto, esta biblioteca intenta establecer una conexión cifrada y falla si no puede validar el certificado del servidor SQL. Añadir esta bandera permite que la conexión se establezca en entornos de desarrollo que utilizan certificados no confiables (por ejemplo, autofirmados).