### PR TITLE
feat: Add final cost report with Excel export

### DIFF
--- a/Controllers/HomeController.cs
+++ b/Controllers/HomeController.cs
@@ -9,6 +9,7 @@ using System.Data;
 using Microsoft.Data.SqlClient;
 using System;
 using System.Linq;
+using Dapper;
 
 
 public class HomeController : Controller
@@ -155,5 +156,29 @@ public class HomeController : Controller
         command.Parameters.AddWithValue("@CodigoInsumo", relacion.CodigoInsumo);
         command.Parameters.AddWithValue("@Cantidad", relacion.Cantidad);
         await command.ExecuteNonQueryAsync();
+    }
+
+    public async Task<IActionResult> Resultados()
+    {
+        List<ReporteFinalViewModel> model;
+        using (var connection = new SqlConnection(_configuration.GetConnectionString("DefaultConnection")))
+        {
+            await connection.OpenAsync();
+            model = (await connection.QueryAsync<ReporteFinalViewModel>("ObtenerReporteFinal", commandType: CommandType.StoredProcedure)).ToList();
+        }
+        return View(model);
+    }
+
+    public async Task<IActionResult> DescargarResultados()
+    {
+        List<ReporteFinalViewModel> model;
+        using (var connection = new SqlConnection(_configuration.GetConnectionString("DefaultConnection")))
+        {
+            await connection.OpenAsync();
+            model = (await connection.QueryAsync<ReporteFinalViewModel>("ObtenerReporteFinal", commandType: CommandType.StoredProcedure)).ToList();
+        }
+
+        byte[] fileContents = _excelService.CrearExcelReporteFinal(model);
+        return File(fileContents, "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet", "ReporteFinalCostos.xlsx");
     }
 }

--- a/Models/BD.cs
+++ b/Models/BD.cs
@@ -100,4 +100,5 @@ public static class BD
             return conexion.Query<TipoInsumo>("SELECT * FROM Tipos_Insumo").ToList();
         }
     }
+
 }

--- a/Models/ExcelService.cs
+++ b/Models/ExcelService.cs
@@ -195,5 +195,38 @@ namespace Zenko.Services
             }
             return relaciones;
         }
+
+        public byte[] CrearExcelReporteFinal(List<ReporteFinalViewModel> reporte)
+        {
+            using (var package = new ExcelPackage())
+            {
+                var worksheet = package.Workbook.Worksheets.Add("Reporte Final");
+
+                // Encabezados
+                worksheet.Cells[1, 1].Value = "Producto";
+                worksheet.Cells[1, 2].Value = "Código Producto";
+                worksheet.Cells[1, 3].Value = "Código Insumo";
+                worksheet.Cells[1, 4].Value = "Costo Insumo";
+                worksheet.Cells[1, 5].Value = "Cantidad";
+                worksheet.Cells[1, 6].Value = "Costo Total";
+
+                // Datos
+                int row = 2;
+                foreach (var item in reporte)
+                {
+                    worksheet.Cells[row, 1].Value = item.NombreProducto;
+                    worksheet.Cells[row, 2].Value = item.CodigoProducto;
+                    worksheet.Cells[row, 3].Value = item.CodigoInsumo;
+                    worksheet.Cells[row, 4].Value = item.CostoInsumo;
+                    worksheet.Cells[row, 5].Value = item.Cantidad;
+                    worksheet.Cells[row, 6].Value = item.CostoTotal;
+                    row++;
+                }
+
+                worksheet.Cells.AutoFitColumns();
+
+                return package.GetAsByteArray();
+            }
+        }
     }
 }

--- a/Models/ReporteFinalViewModel.cs
+++ b/Models/ReporteFinalViewModel.cs
@@ -1,0 +1,14 @@
+using System;
+
+namespace Zenko.Models
+{
+    public class ReporteFinalViewModel
+    {
+        public string NombreProducto { get; set; }
+        public string CodigoProducto { get; set; }
+        public string CodigoInsumo { get; set; }
+        public decimal CostoInsumo { get; set; }
+        public decimal Cantidad { get; set; }
+        public decimal CostoTotal { get; set; }
+    }
+}

--- a/Views/Home/Resultados.cshtml
+++ b/Views/Home/Resultados.cshtml
@@ -1,104 +1,61 @@
-@model Zenko.Models.ResultadoViewModel
-@using System.Linq;
-
+@model List<Zenko.Models.ReporteFinalViewModel>
+@using System.Linq
 @{
-    ViewData["Title"] = "Resultados del Cálculo de Costos";
+    ViewData["Title"] = "Reporte Final de Costos";
+    var productosAgrupados = Model.GroupBy(r => new { r.CodigoProducto, r.NombreProducto });
+    decimal granTotal = 0;
 }
 
-<h2>@ViewData["Title"]</h2>
+<h1>@ViewData["Title"]</h1>
 
-@if (!string.IsNullOrEmpty(Model.MensajeError))
+<div class="text-right mb-3">
+    <a asp-action="DescargarResultados" class="btn btn-success">Descargar como Excel</a>
+</div>
+
+@if (!Model.Any())
 {
-    <div class="alert alert-warning" role="alert">
-        @Model.MensajeError
+    <p>No hay datos para mostrar. Por favor, suba los archivos de insumos y productos primero.</p>
+}
+else
+{
+    foreach (var grupo in productosAgrupados)
+    {
+        <h3>@grupo.Key.NombreProducto (@grupo.Key.CodigoProducto)</h3>
+        <table class="table table-bordered table-striped">
+            <thead>
+                <tr>
+                    <th>Código Insumo</th>
+                    <th>Costo Unitario</th>
+                    <th>Cantidad</th>
+                    <th>Costo Total Insumo</th>
+                </tr>
+            </thead>
+            <tbody>
+                @foreach (var item in grupo)
+                {
+                    <tr>
+                        <td>@item.CodigoInsumo</td>
+                        <td>@item.CostoInsumo.ToString("C")</td>
+                        <td>@item.Cantidad</td>
+                        <td>@item.CostoTotal.ToString("C")</td>
+                    </tr>
+                }
+            </tbody>
+            <tfoot>
+                <tr>
+                    <td colspan="3" class="text-right"><strong>Subtotal Producto:</strong></td>
+                    @{
+                        decimal subtotal = grupo.Sum(i => i.CostoTotal);
+                        granTotal += subtotal;
+                    }
+                    <td><strong>@subtotal.ToString("C")</strong></td>
+                </tr>
+            </tfoot>
+        </table>
+    }
+
+    <hr />
+    <div class="text-right">
+        <h3>Gran Total: @granTotal.ToString("C")</h3>
     </div>
 }
-
-@if (Model.TelasDetalle.Any() || Model.AviosDetalle.Any())
-{
-    <h2>Resumen de Costos</h2>
-    <table class="table">
-        <tr>
-            <th>Costo Total de Telas:</th>
-            <td>@Model.CostoTotalTelas.ToString("C")</td>
-        </tr>
-        <tr>
-            <th>Costo Total de Avíos:</th>
-            <td>@Model.CostoTotalAvios.ToString("C")</td>
-        </tr>
-        <tr>
-            <th>Costo Total General:</th>
-            <td><strong>@Model.CostoTotalGeneral.ToString("C")</strong></td>
-        </tr>
-    </table>
-
-    @if (Model.TelasDetalle.Any())
-    {
-        <h3>Detalle de Telas</h3>
-        <table class="table table-striped">
-            <thead>
-                <tr>
-                    <th>Código</th>
-                    <th>Descripción</th>
-                    <th>Proveedor</th>
-                    <th class="text-end">Costo por Metro</th>
-                </tr>
-            </thead>
-            <tbody>
-                @foreach (var tela in Model.TelasDetalle)
-                {
-                    <tr>
-                        <td>@tela.Codigo</td>
-                        <td>@tela.Descripcion</td>
-                        <td>@tela.Proveedor</td>
-                        <td class="text-end">@tela.CostoPorMetro.ToString("C")</td>
-                    </tr>
-                }
-            </tbody>
-        </table>
-    }
-    else if (string.IsNullOrEmpty(Model.MensajeError))
-    {
-        <p>No se procesaron datos de telas.</p>
-    }
-
-    @if (Model.AviosDetalle.Any())
-    {
-        <h3>Detalle de Avíos</h3>
-        <table class="table table-striped">
-            <thead>
-                <tr>
-                    <th>Código</th>
-                    <th>Descripción</th>
-                    <th>Proveedor</th>
-                    <th>Unidad Medida</th>
-                    <th class="text-end">Costo por Unidad</th>
-                </tr>
-            </thead>
-            <tbody>
-                @foreach (var avio in Model.AviosDetalle)
-                {
-                    <tr>
-                        <td>@avio.Codigo</td>
-                        <td>@avio.Descripcion</td>
-                        <td>@avio.Proveedor</td>
-                        <td>@avio.UnidadMedida</td>
-                        <td class="text-end">@avio.CostoUnidad.ToString("C")</td>
-                    </tr>
-                }
-            </tbody>
-        </table>
-    }
-    else if (string.IsNullOrEmpty(Model.MensajeError))
-    {
-        <p>No se procesaron datos de avíos.</p>
-    }
-}
-else if (string.IsNullOrEmpty(Model.MensajeError)) // Si no hay detalles y no hay un error general
-{
-    <p>No hay datos de costos para mostrar. Por favor, cargue los archivos Excel.</p>
-}
-
-<p>
-    <a asp-action="Index" class="btn btn-primary">Volver a Cargar Archivos</a>
-</p>

--- a/Views/Shared/_Layout.cshtml
+++ b/Views/Shared/_Layout.cshtml
@@ -24,6 +24,9 @@
                     <li class="nav-item">
                         <a class="nav-link text-dark" asp-area="" asp-controller="Home" asp-action="SubirProductos">Subir Productos</a>
                     </li>
+                    <li class="nav-item">
+                        <a class="nav-link text-dark" asp-area="" asp-controller="Home" asp-action="Resultados">Reporte Final</a>
+                    </li>
                 </ul>
             </div>
             <div>

--- a/Zenko.sql
+++ b/Zenko.sql
@@ -148,6 +148,29 @@ BEGIN
 END;
 GO
 
+CREATE PROCEDURE dbo.ObtenerReporteFinal
+AS
+BEGIN
+    SET NOCOUNT ON;
+
+    SELECT
+        p.Nombre AS NombreProducto,
+        p.CodigoProducto,
+        i.CodigoInsumo,
+        i.Costo AS CostoInsumo,
+        pi.Cantidad,
+        (i.Costo * pi.Cantidad) AS CostoTotal
+    FROM
+        Productos p
+    JOIN
+        ProductoInsumo pi ON p.IdProducto = pi.IdProducto
+    JOIN
+        Insumos i ON pi.CodigoInsumo = i.CodigoInsumo
+    ORDER BY
+        p.Nombre, i.CodigoInsumo;
+END;
+GO
+
 CREATE PROCEDURE dbo.UpsertProductoInsumo
     @CodigoProducto NVARCHAR(20),
     @CodigoInsumo NVARCHAR(20),


### PR DESCRIPTION
This commit introduces a new feature that allows you to view a final cost report and download it as an Excel file.

The changes include:
- A new stored procedure `ObtenerReporteFinal` to query the database for the report data.
- A new view model `ReporteFinalViewModel` to represent the report data.
- A new page at `/Home/Resultados` to display the report, grouped by product with subtotals and a grand total.
- An Excel export functionality triggered by a download button on the report page.
- A navigation link in the main layout to the new report page.