### PR TITLE
feat: Add final cost report and improve product upload logic

### DIFF
--- a/Models/BD.cs
+++ b/Models/BD.cs
@@ -100,5 +100,4 @@ public static class BD
             return conexion.Query<TipoInsumo>("SELECT * FROM Tipos_Insumo").ToList();
         }
     }
-
 }

--- a/Zenko.sql
+++ b/Zenko.sql
@@ -148,6 +148,24 @@ BEGIN
 END;
 GO
 
+CREATE TYPE dbo.CodigoInsumoList AS TABLE (
+    CodigoInsumo NVARCHAR(20) PRIMARY KEY
+);
+GO
+
+CREATE PROCEDURE dbo.FiltrarInsumosNoExistentes
+    @CodigosInsumo dbo.CodigoInsumoList READONLY
+AS
+BEGIN
+    SET NOCOUNT ON;
+
+    SELECT ci.CodigoInsumo
+    FROM @CodigosInsumo ci
+    LEFT JOIN Insumos i ON ci.CodigoInsumo = i.CodigoInsumo
+    WHERE i.CodigoInsumo IS NULL;
+END;
+GO
+
 CREATE PROCEDURE dbo.ObtenerReporteFinal
 AS
 BEGIN


### PR DESCRIPTION
This commit introduces a new feature to generate a final cost report and improves the product upload workflow.

New Features:
- A "Final Report" page (`/Home/Resultados`) that displays a detailed cost breakdown for each product, grouped by product with subtotals and a grand total.
- An option to download the final report as an Excel file.

Improvements:
- The product upload process (`/Home/SubirProductos`) now automatically creates new supplies (insumos) if they are present in the upload file but not in the database. These new supplies are created with a default cost of 0, preventing import failures and improving your workflow.