### PR TITLE
fix: Correct exception handling scope in product upload

### DIFF
--- a/Controllers/HomeController.cs
+++ b/Controllers/HomeController.cs
@@ -119,86 +119,83 @@ public class HomeController : Controller
             return View();
         }
 
-        List<ProductoInsumoExcel> relaciones;
+        List<ProductoInsumoExcel> relaciones = new List<ProductoInsumoExcel>();
+
         try
         {
             relaciones = _excelService.LeerProductoInsumos(archivosExcel);
+
+            if (!relaciones.Any())
+            {
+                ModelState.AddModelError("", "El archivo no contiene filas de datos válidas o no se pudieron procesar las relaciones.");
+                return View();
+            }
+
+            using (var connection = new SqlConnection(_configuration.GetConnectionString("DefaultConnection")))
+            {
+                await connection.OpenAsync();
+
+                var codigosInsumoUnicos = relaciones.Select(r => r.CodigoInsumo).Distinct().ToList();
+                var dt = new DataTable();
+                dt.Columns.Add("CodigoInsumo", typeof(string));
+                foreach (var codigo in codigosInsumoUnicos)
+                {
+                    dt.Rows.Add(codigo);
+                }
+
+                var insumosACrear = new List<string>();
+                using (var command = new SqlCommand("dbo.FiltrarInsumosNoExistentes", connection))
+                {
+                    command.CommandType = CommandType.StoredProcedure;
+                    var tvpParam = command.Parameters.AddWithValue("@CodigosInsumo", dt);
+                    tvpParam.SqlDbType = SqlDbType.Structured;
+                    tvpParam.TypeName = "dbo.CodigoInsumoList";
+
+                    using (var reader = await command.ExecuteReaderAsync())
+                    {
+                        while (await reader.ReadAsync())
+                        {
+                            insumosACrear.Add(reader.GetString(0));
+                        }
+                    }
+                }
+
+                foreach (var codigoInsumo in insumosACrear)
+                {
+                    int idTipoInsumo = await ObtenerOInsertarTipoInsumo(connection, codigoInsumo);
+                    await InsertarInsumo(connection, new Insumo
+                    {
+                        CodigoInsumo = codigoInsumo,
+                        IdTipoInsumo = idTipoInsumo,
+                        Costo = 0,
+                        FechaRegistro = DateTime.Now
+                    });
+                }
+
+                var productosUnicos = relaciones
+                    .GroupBy(r => r.CodigoProducto)
+                    .Select(g => g.First())
+                    .ToList();
+
+                foreach (var producto in productosUnicos)
+                {
+                    await UpsertProducto(connection, new ProductoExcel { CodigoProducto = producto.CodigoProducto, NombreProducto = producto.NombreProducto });
+                }
+
+                foreach (var relacion in relaciones)
+                {
+                    await UpsertProductoInsumo(connection, relacion);
+                }
+            }
+
+            ViewData["RelacionesProcesadas"] = relaciones;
+            return View();
         }
         catch (Exception ex)
         {
-            ModelState.AddModelError("", $"Error al leer el archivo Excel: {ex.Message}");
+            ModelState.AddModelError("", $"Error al procesar el archivo: {ex.Message}");
             return View();
         }
-
-        if (!relaciones.Any())
-        {
-            ModelState.AddModelError("", "El archivo no contiene filas de datos válidas o no se pudieron procesar las relaciones.");
-            return View();
-        }
-
-        using var connection = new SqlConnection(_configuration.GetConnectionString("DefaultConnection"));
-        await connection.OpenAsync();
-
-        // 1. Obtener todos los insumos únicos del archivo Excel
-        var codigosInsumoUnicos = relaciones.Select(r => r.CodigoInsumo).Distinct().ToList();
-
-        // 2. Identificar qué insumos no existen en la base de datos
-        var dt = new DataTable();
-        dt.Columns.Add("CodigoInsumo", typeof(string));
-        foreach (var codigo in codigosInsumoUnicos)
-        {
-            dt.Rows.Add(codigo);
-        }
-
-        var insumosACrear = new List<string>();
-        using (var command = new SqlCommand("dbo.FiltrarInsumosNoExistentes", connection))
-        {
-            command.CommandType = CommandType.StoredProcedure;
-            var tvpParam = command.Parameters.AddWithValue("@CodigosInsumo", dt);
-            tvpParam.SqlDbType = SqlDbType.Structured;
-            tvpParam.TypeName = "dbo.CodigoInsumoList";
-
-            using (var reader = await command.ExecuteReaderAsync())
-            {
-                while (await reader.ReadAsync())
-                {
-                    insumosACrear.Add(reader.GetString(0));
-                }
-            }
-        }
-
-        // 3. Crear los insumos no existentes con costo 0
-        foreach (var codigoInsumo in insumosACrear)
-        {
-            int idTipoInsumo = await ObtenerOInsertarTipoInsumo(connection, codigoInsumo);
-            await InsertarInsumo(connection, new Insumo
-            {
-                CodigoInsumo = codigoInsumo,
-                IdTipoInsumo = idTipoInsumo,
-                Costo = 0, // Costo por defecto
-                FechaRegistro = DateTime.Now
-            });
-        }
-
-        // 4. Agrupar por producto para asegurar que cada producto se inserte/actualice una sola vez
-        var productosUnicos = relaciones
-            .GroupBy(r => r.CodigoProducto)
-            .Select(g => g.First())
-            .ToList();
-
-        foreach (var producto in productosUnicos)
-        {
-            await UpsertProducto(connection, new ProductoExcel { CodigoProducto = producto.CodigoProducto, NombreProducto = producto.NombreProducto });
-        }
-
-        // 5. Ahora, insertar/actualizar las relaciones producto-insumo
-        foreach (var relacion in relaciones)
-        {
-            await UpsertProductoInsumo(connection, relacion);
-        }
-
-        ViewData["RelacionesProcesadas"] = relaciones;
-        return View();
     }
 
     private async Task<int> UpsertProducto(SqlConnection connection, ProductoExcel producto)


### PR DESCRIPTION
This commit fixes a bug where the `try...catch` block in the `SubirProductos` action only covered the initial Excel file reading, not the subsequent database processing. This caused the application to crash with an unhandled exception if a database error occurred (e.g., an invalid supply code).

The `try...catch` block has been extended to wrap the entire unit of work, including all database calls. This ensures that any error, whether from file parsing or database processing, is caught gracefully and displayed to you on the upload page, as originally intended.