### PR TITLE
fix: Make supply type classification flexible

### DIFF
--- a/Zenko.sql
+++ b/Zenko.sql
@@ -63,13 +63,8 @@ BEGIN
 
     IF (@Prefijo = 'VK' OR @Prefijo = 'VM' OR @Prefijo = 'IK' OR @Prefijo = 'IM')
         SET @Tipo = 'Tela';
-    ELSE IF (@Prefijo = 'VA' OR @Prefijo = 'IA')
+    ELSE -- Si no es Tela, se asume que es Avio. Incluye 'VA', 'IA', y cualquier otro prefijo.
         SET @Tipo = 'Avio';
-    ELSE
-    BEGIN
-        RAISERROR('Prefijo no valido para tipo de insumo.', 16, 1);
-        RETURN;
-    END
 
     SELECT @IdTipoInsumo = IdTipoInsumo FROM Tipos_Insumo WHERE CodigoPrefijo = @Prefijo;
 


### PR DESCRIPTION
This commit addresses the final data processing issue where supply codes that did not match a predefined prefix format would cause an error.

The `ObtenerOInsertarTipoInsumoPorCodigo` stored procedure has been modified. Instead of raising an error for an unrecognized supply code prefix, it now defaults to classifying the supply as 'Avío'. This makes the system more flexible and resilient to variations in the input data, as requested by you.