### PR TITLE
fix: Add missing using directives in Program.cs

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -1,6 +1,8 @@
 using Microsoft.AspNetCore.Builder;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Configuration;
+using System;
 using Zenko.Services; // Agregar para que reconozca tus servicios
 
 var builder = WebApplication.CreateBuilder(args);


### PR DESCRIPTION
Resolves two compilation errors (CS1061 and CS0246) in Program.cs by adding the required `using System;` and `using Microsoft.Extensions.Configuration;` directives. This was a regression that occurred during a previous refactoring.