### PR TITLE
fix: Make @Descripcion parameter optional in InsertarInsumo SP

### DIFF
--- a/Zenko.sql
+++ b/Zenko.sql
@@ -92,7 +92,7 @@ GO
 CREATE PROCEDURE dbo.InsertarInsumo
     @CodigoInsumo NVARCHAR(20),
     @IdTipoInsumo INT,
-    @Descripcion NVARCHAR(255),
+    @Descripcion NVARCHAR(255) = NULL,
     @Costo DECIMAL(10, 2),
     @FechaRegistro DATETIME
 AS


### PR DESCRIPTION
This commit fixes a runtime crash on the 'Subir Insumos' page. The `InsertarInsumo` stored procedure expected a `@Descripcion` parameter, but the calling C# code for this specific page did not provide one, as it works with a simpler data model.

The fix makes the `@Descripcion` parameter optional in the stored procedure, defaulting to NULL. This allows the older 'Subir Insumos' page to function correctly while still allowing the new 'Ficha Técnica' upload to provide a description when available.