### PR TITLE
Enhance card and button hover effects

### DIFF
--- a/wwwroot/css/Layout.css
+++ b/wwwroot/css/Layout.css
@@ -65,15 +65,15 @@ a:hover {
     font-weight: 500;
     padding: 12px 30px;
     border-radius: 8px;
-    transition: background-color 0.3s ease, transform 0.2s ease, box-shadow 0.3s ease;
+    transition: background-color 0.3s ease, transform 0.3s ease, box-shadow 0.3s ease;
 }
 
 .btn-primary:hover {
     background-color: #4a78c8;
     border-color: #4a78c8;
     color: #fff;
-    transform: translateY(-2px);
-    box-shadow: 0 4px 10px rgba(0,0,0,0.1);
+    transform: scale(1.03);
+    box-shadow: 0 6px 15px rgba(0,0,0,0.15);
 }
 
 .btn:focus, .form-control:focus {

--- a/wwwroot/css/site.css
+++ b/wwwroot/css/site.css
@@ -5,6 +5,12 @@
     border-radius: 8px;
     box-shadow: 0 1px 3px rgba(0,0,0,0.04);
     margin-bottom: 2rem;
+    transition: box-shadow 0.3s ease, transform 0.3s ease;
+}
+
+.card:hover {
+    box-shadow: 0 4px 12px rgba(0,0,0,0.15);
+    transform: translateY(-2px);
 }
 
 .card-header {


### PR DESCRIPTION
## Summary
- Intensify card hover by adding transition and stronger shadow
- Smooth primary button hover with scale transform and deeper shadow

## Testing
- `dotnet build`


------
https://chatgpt.com/codex/tasks/task_e_68ac57dd3858832d939288e7a7a9b93d