### PR TITLE
Refactor styles in Resultados view and enable responsive tables

### DIFF
--- a/Views/Home/Resultados.cshtml
+++ b/Views/Home/Resultados.cshtml
@@ -11,7 +11,7 @@
 
 <div class="text-right mb-3">
     <button id="sort-button" class="btn btn-primary">Ordenar A-Z</button>
-    <a asp-action="DescargarResultados" class="btn btn-success" style="margin-left: 10px;">Descargar como Excel</a>
+    <a asp-action="DescargarResultados" class="btn btn-success ml-2">Descargar como Excel</a>
 </div>
 
 @if (!Model.Any())
@@ -25,7 +25,7 @@ else
         {
             var producto = grupoProducto.Key;
             <div class="producto-card" data-nombre="@producto.ModeloNombre">
-                <h2 style="font-weight: bold; color: #0056b3; border-bottom: 2px solid #0056b3; padding-bottom: 5px; margin-top: 20px;">
+                <h2 class="producto-titulo">
                     @producto.ModeloNombre (@producto.ModeloCodigo)
                 </h2>
 
@@ -36,11 +36,12 @@ else
                 @foreach (var grupoVariante in variantesAgrupadas)
                 {
                     var variante = grupoVariante.Key;
-                    <h4 style="font-weight: bold; color: #333; margin-top: 15px;">
+                    <h4 class="variante-titulo">
                         @variante.VarianteNombre (@variante.VarianteCodigo)
                     </h4>
 
-                    <table class="table table-bordered table-striped table-sm" style="margin-top: 10px;">
+                    <div class="table-responsive mt-3">
+                    <table class="table table-bordered table-striped table-sm">
                         <thead class="thead-light">
                             <tr>
                                 <th>Código Insumo</th>
@@ -73,6 +74,7 @@ else
                             </tr>
                         </tfoot>
                     </table>
+                    </div>
                 }
             </div>
         }

--- a/wwwroot/css/Layout.css
+++ b/wwwroot/css/Layout.css
@@ -108,3 +108,17 @@ a:hover {
     outline: none;
     box-shadow: 0 0 0 3px rgba(90, 141, 222, 0.3) !important;
 }
+
+.producto-titulo {
+    font-weight: bold;
+    color: #0056b3;
+    border-bottom: 2px solid #0056b3;
+    padding-bottom: 5px;
+    margin-top: 20px;
+}
+
+.variante-titulo {
+    font-weight: bold;
+    color: #333;
+    margin-top: 15px;
+}


### PR DESCRIPTION
## Summary
- replace inline styles in Resultados view with semantic classes and clean up inline attributes
- wrap tables in a responsive container for mobile scrolling
- define producto-titulo and variante-titulo classes in Layout.css

## Testing
- `dotnet build`


------
https://chatgpt.com/codex/tasks/task_e_68ac615406d0832dabebc3acf42d8d80