### PR TITLE
Add simple login with session support

### DIFF
--- a/Controllers/AccountController.cs
+++ b/Controllers/AccountController.cs
@@ -1,0 +1,39 @@
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Configuration;
+
+public class AccountController : Controller
+{
+    private readonly IConfiguration _configuration;
+
+    public AccountController(IConfiguration configuration)
+    {
+        _configuration = configuration;
+    }
+
+    [HttpGet]
+    public IActionResult Login()
+    {
+        return View();
+    }
+
+    [HttpPost]
+    public IActionResult Login(string username, string password)
+    {
+        var connectionString = _configuration.GetConnectionString("DefaultConnection");
+        if (BD.ValidarUsuario(connectionString, username, password))
+        {
+            HttpContext.Session.SetString("Usuario", username);
+            return RedirectToAction("Index", "Home");
+        }
+        ViewBag.Error = "Credenciales inválidas";
+        return View();
+    }
+
+    [HttpPost]
+    public IActionResult Logout()
+    {
+        HttpContext.Session.Clear();
+        return RedirectToAction("Login");
+    }
+}

--- a/Controllers/HomeController.cs
+++ b/Controllers/HomeController.cs
@@ -29,18 +29,31 @@ public class HomeController : Controller
     [HttpGet]
     public IActionResult Index()
     {
+        if (HttpContext.Session.GetString("Usuario") == null)
+        {
+            return RedirectToAction("Login", "Account");
+        }
         return View();
     }
 
     [HttpGet]
     public IActionResult SubirProductos()
     {
+        if (HttpContext.Session.GetString("Usuario") == null)
+        {
+            return RedirectToAction("Login", "Account");
+        }
         return View();
     }
 
     [HttpPost]
     public async Task<IActionResult> Index(List<IFormFile> archivosExcel)
     {
+        if (HttpContext.Session.GetString("Usuario") == null)
+        {
+            return RedirectToAction("Login", "Account");
+        }
+
         if (archivosExcel == null || archivosExcel.Count == 0)
         {
             return BadRequest("No files uploaded");
@@ -75,6 +88,11 @@ public class HomeController : Controller
     [HttpPost]
     public async Task<IActionResult> SubirProductos(List<IFormFile> archivosExcel)
     {
+        if (HttpContext.Session.GetString("Usuario") == null)
+        {
+            return RedirectToAction("Login", "Account");
+        }
+
         if (archivosExcel == null || archivosExcel.Count == 0)
         {
             ModelState.AddModelError("", "Por favor, suba al menos un archivo Excel de productos.");
@@ -184,6 +202,10 @@ public class HomeController : Controller
 
     public async Task<IActionResult> Resultados()
     {
+        if (HttpContext.Session.GetString("Usuario") == null)
+        {
+            return RedirectToAction("Login", "Account");
+        }
         List<ReporteFinalViewModel> model;
         using (var connection = new SqlConnection(_configuration.GetConnectionString("DefaultConnection")))
         {
@@ -195,6 +217,10 @@ public class HomeController : Controller
 
     public async Task<IActionResult> DescargarResultados()
     {
+        if (HttpContext.Session.GetString("Usuario") == null)
+        {
+            return RedirectToAction("Login", "Account");
+        }
         List<ReporteFinalViewModel> model;
         using (var connection = new SqlConnection(_configuration.GetConnectionString("DefaultConnection")))
         {

--- a/Models/BD.cs
+++ b/Models/BD.cs
@@ -100,4 +100,15 @@ public static class BD
             return conexion.Query<TipoInsumo>("SELECT * FROM Tipos_Insumo").ToList();
         }
     }
+
+    public static bool ValidarUsuario(string connectionString, string usuario, string password)
+    {
+        using (var conexion = new SqlConnection(connectionString))
+        {
+            conexion.Open();
+            string sql = "SELECT COUNT(1) FROM Usuarios WHERE NombreUsuario = @usuario AND Password = @password";
+            int count = conexion.QueryFirst<int>(sql, new { usuario, password });
+            return count > 0;
+        }
+    }
 }

--- a/Models/Usuario.cs
+++ b/Models/Usuario.cs
@@ -1,0 +1,6 @@
+public class Usuario
+{
+    public int IdUsuario { get; set; }
+    public string NombreUsuario { get; set; }
+    public string Password { get; set; }
+}

--- a/Program.cs
+++ b/Program.cs
@@ -11,6 +11,11 @@ var builder = WebApplication.CreateBuilder(args);
 // Registramos MVC
 builder.Services.AddControllersWithViews();
 builder.Services.AddSignalR();
+builder.Services.AddDistributedMemoryCache();
+builder.Services.AddSession(options =>
+{
+    options.IdleTimeout = TimeSpan.FromMinutes(30);
+});
 
 // Registramos los servicios para inyección de dependencias
 builder.Services.AddScoped<ExcelService>();
@@ -38,6 +43,7 @@ if (!app.Environment.IsDevelopment())
 app.UseHttpsRedirection();
 app.UseStaticFiles();
 app.UseRouting();
+app.UseSession();
 
 // Ruta por defecto
 app.MapControllerRoute(

--- a/Views/Account/Login.cshtml
+++ b/Views/Account/Login.cshtml
@@ -1,0 +1,23 @@
+@{
+    ViewData["Title"] = "Login";
+}
+
+<h2>Iniciar Sesión</h2>
+
+<form asp-action="Login" method="post">
+    <div class="mb-3">
+        <label for="username" class="form-label">Usuario</label>
+        <input type="text" class="form-control" id="username" name="username" required />
+    </div>
+    <div class="mb-3">
+        <label for="password" class="form-label">Contraseña</label>
+        <input type="password" class="form-control" id="password" name="password" required />
+    </div>
+    <button type="submit" class="btn btn-primary">Ingresar</button>
+    <a href="#" class="btn btn-link">Olvidé mi contraseña</a>
+</form>
+
+@if (ViewBag.Error != null)
+{
+    <div class="text-danger mt-2">@ViewBag.Error</div>
+}

--- a/Views/Shared/_Layout.cshtml
+++ b/Views/Shared/_Layout.cshtml
@@ -34,6 +34,16 @@
                         <a class="nav-link text-dark" asp-area="" asp-controller="Home" asp-action="Resultados">Reporte Final</a>
                     </li>
                 </ul>
+                @if (Context.Session.GetString("Usuario") != null)
+                {
+                    <form asp-controller="Account" asp-action="Logout" method="post" class="d-inline">
+                        <button type="submit" class="btn btn-link">Cerrar sesión (@Context.Session.GetString("Usuario"))</button>
+                    </form>
+                }
+                else
+                {
+                    <a class="nav-link text-dark" asp-controller="Account" asp-action="Login">Iniciar Sesión</a>
+                }
                 <button id="theme-toggle" class="btn btn-outline-secondary">Modo oscuro</button>
             </div>
         </nav>

--- a/Views/_ViewImports.cshtml
+++ b/Views/_ViewImports.cshtml
@@ -1,2 +1,3 @@
-﻿@using ZenkoApp.Models
+@using ZenkoApp.Models
+@using Microsoft.AspNetCore.Http
 @addTagHelper *, Microsoft.AspNetCore.Mvc.TagHelpers

--- a/Zenko.sql
+++ b/Zenko.sql
@@ -268,3 +268,18 @@ BEGIN
     END
 END;
 GO
+
+/****** Object:  Table [dbo].[Usuarios]    Script Date: 18/8/2025 08:39:38 ******/
+SET ANSI_NULLS ON
+GO
+SET QUOTED_IDENTIFIER ON
+GO
+CREATE TABLE [dbo].[Usuarios](
+    [IdUsuario] INT IDENTITY(1,1) NOT NULL,
+    [NombreUsuario] NVARCHAR(50) NOT NULL,
+    [Password] NVARCHAR(50) NOT NULL,
+ CONSTRAINT [PK_Usuarios] PRIMARY KEY CLUSTERED ([IdUsuario] ASC)
+) ON [PRIMARY]
+GO
+INSERT INTO [dbo].[Usuarios] (NombreUsuario, Password) VALUES ('admin', 'admin');
+GO


### PR DESCRIPTION
## Summary
- add session configuration and basic user validation
- implement account controller and login page
- create Usuarios table and model for authentication

## Testing
- `dotnet build`


------
https://chatgpt.com/codex/tasks/task_e_68b585f7a2d0832d9511fa662dad66d7