### PR TITLE
Fix decimal parsing for Excel uploads

### DIFF
--- a/Models/ExcelService.cs
+++ b/Models/ExcelService.cs
@@ -115,7 +115,31 @@ namespace Zenko.Services
                 return -1;
 
             string limpio = valor.Replace("$", "").Trim();
-            limpio = limpio.Replace(".", "").Replace(",", ".");
+
+            bool tieneComa = limpio.Contains(',');
+            bool tienePunto = limpio.Contains('.');
+
+            if (tieneComa && tienePunto)
+            {
+                if (limpio.LastIndexOf(',') > limpio.LastIndexOf('.'))
+                {
+                    limpio = limpio.Replace(".", "");
+                    limpio = limpio.Replace(',', '.');
+                }
+                else
+                {
+                    limpio = limpio.Replace(",", "");
+                }
+            }
+            else if (tieneComa)
+            {
+                limpio = limpio.Replace(".", "");
+                limpio = limpio.Replace(',', '.');
+            }
+            else
+            {
+                limpio = limpio.Replace(",", "");
+            }
 
             if (decimal.TryParse(limpio, NumberStyles.AllowDecimalPoint, CultureInfo.InvariantCulture, out decimal resultado))
                 return resultado;


### PR DESCRIPTION
## Summary
- Handle both dot and comma decimal separators when parsing Excel values for fabrics and trimmings

## Testing
- `dotnet build`

------
https://chatgpt.com/codex/tasks/task_e_68b59c02f0a4832d8872874bb0faba23