### PR TITLE
Add consumption upload workflow

### DIFF
--- a/Models/CalculoService.cs
+++ b/Models/CalculoService.cs
@@ -1,3 +1,4 @@
+using System;
 using Zenko.Models;
 using System.Collections.Generic;
 using System.Linq;
@@ -23,6 +24,74 @@ namespace Zenko.Services
             }
 
             return resultado;
+        }
+
+        public ConsumoResultadoViewModel CalcularConsumosPromedio(List<ConsumoExcel> registros)
+        {
+            var resultado = new ConsumoResultadoViewModel();
+
+            if (registros == null || registros.Count == 0)
+            {
+                return resultado;
+            }
+
+            resultado.RegistrosProcesados = registros.Count;
+
+            resultado.ConsumosPorOperacion = registros
+                .Where(r => !string.IsNullOrWhiteSpace(r.OpNumero) && !string.IsNullOrWhiteSpace(r.InsumoCodigo))
+                .GroupBy(r => new { r.OpNumero, r.InsumoCodigo, Costo = r.CostoInsumoOperacion })
+                .Select(g => new ConsumoPromedioPorOperacion
+                {
+                    OpNumero = g.Key.OpNumero,
+                    InsumoCodigo = g.Key.InsumoCodigo,
+                    InsumoDescripcion = g.Select(x => x.InsumoDescripcion).FirstOrDefault(d => !string.IsNullOrWhiteSpace(d)),
+                    CostoInsumoOperacion = g.Key.Costo,
+                    ConsumoPromedio = CalcularPromedio(g.Select(x => x.ConsumoPromedio)),
+                    ConsumoReal = CalcularPromedio(g.Select(x => x.ConsumoRealOperacion)),
+                    CantidadRemitidaTotal = g.Where(x => x.CantidadRemitida.HasValue).Sum(x => x.CantidadRemitida ?? 0m),
+                    DevolucionTotal = g.Where(x => x.Devolucion.HasValue).Sum(x => x.Devolucion ?? 0m),
+                    ModeloCodigo = g.Select(x => x.ModeloCodigo).FirstOrDefault(m => !string.IsNullOrWhiteSpace(m)),
+                    ModeloNombre = g.Select(x => x.ModeloNombre).FirstOrDefault(m => !string.IsNullOrWhiteSpace(m))
+                })
+                .OrderBy(r => r.OpNumero)
+                .ThenBy(r => r.InsumoCodigo)
+                .ToList();
+
+            resultado.ConsumosPorProducto = registros
+                .Where(r => !string.IsNullOrWhiteSpace(r.ModeloCodigo) && !string.IsNullOrWhiteSpace(r.InsumoCodigo))
+                .GroupBy(r => new { r.ModeloCodigo, r.ModeloNombre, r.InsumoCodigo })
+                .Select(g => new ConsumoPromedioPorProducto
+                {
+                    ModeloCodigo = g.Key.ModeloCodigo,
+                    ModeloNombre = g.Key.ModeloNombre,
+                    InsumoCodigo = g.Key.InsumoCodigo,
+                    InsumoDescripcion = g.Select(x => x.InsumoDescripcion).FirstOrDefault(d => !string.IsNullOrWhiteSpace(d)),
+                    ConsumoPromedio = CalcularPromedio(g.Select(x => x.ConsumoPromedio)),
+                    ConsumoReal = CalcularPromedio(g.Select(x => x.ConsumoRealOperacion)),
+                    CantidadRemitidaTotal = g.Where(x => x.CantidadRemitida.HasValue).Sum(x => x.CantidadRemitida ?? 0m),
+                    DevolucionTotal = g.Where(x => x.Devolucion.HasValue).Sum(x => x.Devolucion ?? 0m),
+                    OperacionesDistintas = g.Select(x => x.OpNumero).Where(op => !string.IsNullOrWhiteSpace(op)).Distinct().Count()
+                })
+                .OrderBy(r => r.ModeloCodigo)
+                .ThenBy(r => r.InsumoCodigo)
+                .ToList();
+
+            return resultado;
+        }
+
+        private decimal? CalcularPromedio(IEnumerable<decimal?> valores)
+        {
+            var filtrados = valores
+                .Where(v => v.HasValue)
+                .Select(v => v.Value)
+                .ToList();
+
+            if (!filtrados.Any())
+            {
+                return null;
+            }
+
+            return decimal.Round(filtrados.Average(), 4, System.MidpointRounding.AwayFromZero);
         }
     }
 }

--- a/Models/ConsumoExcel.cs
+++ b/Models/ConsumoExcel.cs
@@ -1,0 +1,23 @@
+using System;
+
+namespace Zenko.Models
+{
+    public class ConsumoExcel
+    {
+        public string Canal { get; set; }
+        public string OpNumero { get; set; }
+        public string ModeloCodigo { get; set; }
+        public string ModeloNombre { get; set; }
+        public string ColorCodigo { get; set; }
+        public string ColorNombre { get; set; }
+        public string InsumoCodigo { get; set; }
+        public string InsumoDescripcion { get; set; }
+        public decimal? CostoInsumoOperacion { get; set; }
+        public DateTime? Fecha { get; set; }
+        public decimal? Corte { get; set; }
+        public decimal? ConsumoPromedio { get; set; }
+        public decimal? CantidadRemitida { get; set; }
+        public decimal? Devolucion { get; set; }
+        public decimal? ConsumoRealOperacion { get; set; }
+    }
+}

--- a/Models/ConsumoPromedioPorOperacion.cs
+++ b/Models/ConsumoPromedioPorOperacion.cs
@@ -1,0 +1,16 @@
+namespace Zenko.Models
+{
+    public class ConsumoPromedioPorOperacion
+    {
+        public string OpNumero { get; set; }
+        public string InsumoCodigo { get; set; }
+        public string InsumoDescripcion { get; set; }
+        public decimal? CostoInsumoOperacion { get; set; }
+        public decimal? ConsumoPromedio { get; set; }
+        public decimal? ConsumoReal { get; set; }
+        public decimal CantidadRemitidaTotal { get; set; }
+        public decimal DevolucionTotal { get; set; }
+        public string ModeloCodigo { get; set; }
+        public string ModeloNombre { get; set; }
+    }
+}

--- a/Models/ConsumoPromedioPorProducto.cs
+++ b/Models/ConsumoPromedioPorProducto.cs
@@ -1,0 +1,15 @@
+namespace Zenko.Models
+{
+    public class ConsumoPromedioPorProducto
+    {
+        public string ModeloCodigo { get; set; }
+        public string ModeloNombre { get; set; }
+        public string InsumoCodigo { get; set; }
+        public string InsumoDescripcion { get; set; }
+        public decimal? ConsumoPromedio { get; set; }
+        public decimal? ConsumoReal { get; set; }
+        public decimal CantidadRemitidaTotal { get; set; }
+        public decimal DevolucionTotal { get; set; }
+        public int OperacionesDistintas { get; set; }
+    }
+}

--- a/Models/ConsumoResultadoViewModel.cs
+++ b/Models/ConsumoResultadoViewModel.cs
@@ -1,0 +1,17 @@
+using System.Collections.Generic;
+
+namespace Zenko.Models
+{
+    public class ConsumoResultadoViewModel
+    {
+        public List<ConsumoPromedioPorOperacion> ConsumosPorOperacion { get; set; }
+        public List<ConsumoPromedioPorProducto> ConsumosPorProducto { get; set; }
+        public int RegistrosProcesados { get; set; }
+
+        public ConsumoResultadoViewModel()
+        {
+            ConsumosPorOperacion = new List<ConsumoPromedioPorOperacion>();
+            ConsumosPorProducto = new List<ConsumoPromedioPorProducto>();
+        }
+    }
+}

--- a/Views/Home/SubirConsumos.cshtml
+++ b/Views/Home/SubirConsumos.cshtml
@@ -1,0 +1,148 @@
+@model Zenko.Models.ConsumoResultadoViewModel
+@{
+    ViewData["Title"] = "Subir Archivos de Consumos";
+}
+
+<div class="card">
+    <div class="card-header">
+        Cargar Archivos de Consumos
+    </div>
+    <div class="card-body">
+        <div asp-validation-summary="All" class="text-danger"></div>
+        <form asp-action="SubirConsumos" method="post" enctype="multipart/form-data">
+            <div class="file-upload-wrapper">
+                <div class="file-upload-icon">
+                    <svg xmlns="http://www.w3.org/2000/svg" width="48" height="48" fill="currentColor" class="bi bi-cloud-upload" viewBox="0 0 16 16">
+                        <path fill-rule="evenodd" d="M4.406 1.342A5.53 5.53 0 0 1 8 0c2.69 0 4.923 2 5.166 4.579C14.758 4.804 16 6.137 16 7.773 16 9.569 14.502 11 12.687 11H10.5a.5.5 0 0 1 0-1h2.188C13.938 10 15 8.981 15 7.773c0-1.216-1.02-2.228-2.313-2.228h-.5v-.5C12.188 2.825 10.328 1 8 1a4.53 4.53 0 0 0-4.242 3.153A4.98 4.98 0 0 0 1.55 8H1.5a.5.5 0 0 1 0-1h.05a4.98 4.98 0 0 0 1.95-3.846A5.53 5.53 0 0 1 4.406 1.342z"/>
+                        <path fill-rule="evenodd" d="M7.646 4.146a.5.5 0 0 1 .708 0l3 3a.5.5 0 0 1-.708.708L8.5 5.707V14.5a.5.5 0 0 1-1 0V5.707L5.354 7.854a.5.5 0 1 1-.708-.708l3-3z"/>
+                    </svg>
+                </div>
+                <label for="archivosConsumo" class="file-upload-label">
+                    Arrastra tus archivos de consumos aquí o haz clic para seleccionar
+                </label>
+                <input type="file" name="archivosExcel" id="archivosConsumo" multiple accept=".xls,.xlsx" />
+            </div>
+            <div id="consumo-file-name" class="text-center"></div>
+            <div class="btn-container">
+                <button type="submit" class="btn btn-primary">Procesar Consumos</button>
+            </div>
+        </form>
+    </div>
+</div>
+
+@if (ViewData["MensajeExito"] != null)
+{
+    <div class="alert alert-success mt-4" role="alert">
+        @ViewData["MensajeExito"]
+    </div>
+}
+
+@if (Model != null && (Model.ConsumosPorOperacion.Any() || Model.ConsumosPorProducto.Any()))
+{
+    <div class="card mt-4">
+        <div class="card-header">
+            Promedio de Consumos por Operación
+        </div>
+        <div class="card-body">
+            <div class="table-responsive">
+                <table class="table table-striped table-hover">
+                    <thead>
+                        <tr>
+                            <th>OP N°</th>
+                            <th>Modelo</th>
+                            <th>Insumo</th>
+                            <th>Costo Operación</th>
+                            <th>Consumo Promedio</th>
+                            <th>Consumo Real</th>
+                            <th>Cantidad Remitida</th>
+                            <th>Devolución</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        @foreach (var item in Model.ConsumosPorOperacion)
+                        {
+                            <tr>
+                                <td>@item.OpNumero</td>
+                                <td>
+                                    <div class="fw-semibold">@item.ModeloCodigo</div>
+                                    <div class="text-muted">@item.ModeloNombre</div>
+                                </td>
+                                <td>
+                                    <div class="fw-semibold">@item.InsumoCodigo</div>
+                                    <div class="text-muted">@item.InsumoDescripcion</div>
+                                </td>
+                                <td>@(item.CostoInsumoOperacion.HasValue ? item.CostoInsumoOperacion.Value.ToString("C") : "-")</td>
+                                <td>@(item.ConsumoPromedio.HasValue ? item.ConsumoPromedio.Value.ToString("N3") : "-")</td>
+                                <td>@(item.ConsumoReal.HasValue ? item.ConsumoReal.Value.ToString("N3") : "-")</td>
+                                <td>@item.CantidadRemitidaTotal.ToString("N3")</td>
+                                <td>@item.DevolucionTotal.ToString("N3")</td>
+                            </tr>
+                        }
+                    </tbody>
+                </table>
+            </div>
+        </div>
+    </div>
+
+    <div class="card mt-4">
+        <div class="card-header">
+            Promedio de Consumos por Producto
+        </div>
+        <div class="card-body">
+            <div class="table-responsive">
+                <table class="table table-striped table-hover">
+                    <thead>
+                        <tr>
+                            <th>Modelo</th>
+                            <th>Insumo</th>
+                            <th>Consumo Promedio</th>
+                            <th>Consumo Real</th>
+                            <th>Cantidad Remitida</th>
+                            <th>Devolución</th>
+                            <th>Operaciones</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        @foreach (var item in Model.ConsumosPorProducto)
+                        {
+                            <tr>
+                                <td>
+                                    <div class="fw-semibold">@item.ModeloCodigo</div>
+                                    <div class="text-muted">@item.ModeloNombre</div>
+                                </td>
+                                <td>
+                                    <div class="fw-semibold">@item.InsumoCodigo</div>
+                                    <div class="text-muted">@item.InsumoDescripcion</div>
+                                </td>
+                                <td>@(item.ConsumoPromedio.HasValue ? item.ConsumoPromedio.Value.ToString("N3") : "-")</td>
+                                <td>@(item.ConsumoReal.HasValue ? item.ConsumoReal.Value.ToString("N3") : "-")</td>
+                                <td>@item.CantidadRemitidaTotal.ToString("N3")</td>
+                                <td>@item.DevolucionTotal.ToString("N3")</td>
+                                <td>@item.OperacionesDistintas</td>
+                            </tr>
+                        }
+                    </tbody>
+                </table>
+            </div>
+        </div>
+    </div>
+}
+
+@section Scripts {
+    <script>
+        document.getElementById('archivosConsumo').addEventListener('change', function (e) {
+            const fileInput = e.target;
+            const display = document.getElementById('consumo-file-name');
+
+            if (fileInput.files && fileInput.files.length > 0) {
+                if (fileInput.files.length === 1) {
+                    display.textContent = 'Archivo seleccionado: ' + fileInput.files[0].name;
+                } else {
+                    display.textContent = fileInput.files.length + ' archivos seleccionados';
+                }
+            } else {
+                display.textContent = '';
+            }
+        });
+    </script>
+}

--- a/Views/Shared/_Layout.cshtml
+++ b/Views/Shared/_Layout.cshtml
@@ -31,6 +31,9 @@
                         <a class="nav-link text-dark" asp-area="" asp-controller="Home" asp-action="SubirProductos">Subir Ficha Técnica</a>
                     </li>
                     <li class="nav-item">
+                        <a class="nav-link text-dark" asp-area="" asp-controller="Home" asp-action="SubirConsumos">Subir Consumos</a>
+                    </li>
+                    <li class="nav-item">
                         <a class="nav-link text-dark" asp-area="" asp-controller="Home" asp-action="Resultados">Reporte Final</a>
                     </li>
                 </ul>


### PR DESCRIPTION
## Summary
- add a new page dedicated to uploading fabric and trim consumption spreadsheets
- parse the new workbook formats, map relevant fields, and compute average consumption by operation and by product/insumo
- surface the aggregated results in a dedicated view and add navigation to access the new workflow

## Testing
- Not run (dotnet CLI is unavailable in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68da6b6670d8832dafaa800d36de7737