### PR TITLE
Handle SignalR absence on home page

### DIFF
--- a/Views/Home/Index.cshtml
+++ b/Views/Home/Index.cshtml
@@ -95,17 +95,22 @@
     <script>
         const form = document.querySelector('form');
         const progressContainer = document.getElementById('progress-container');
-        const connection = new signalR.HubConnectionBuilder().withUrl('/processingHub').build();
 
-        connection.on('ProgressUpdated', (id, porcentaje, estado) => {
-            const bar = document.getElementById(`bar-${id}`);
-            if (bar) {
-                bar.style.width = porcentaje + '%';
-                bar.textContent = `${estado} ${porcentaje}%`;
-            }
-        });
+        if (window.signalR) {
+            const connection = new signalR.HubConnectionBuilder().withUrl('/processingHub').build();
 
-        connection.start();
+            connection.on('ProgressUpdated', (id, porcentaje, estado) => {
+                const bar = document.getElementById(`bar-${id}`);
+                if (bar) {
+                    bar.style.width = porcentaje + '%';
+                    bar.textContent = `${estado} ${porcentaje}%`;
+                }
+            });
+
+            connection.start().catch(error => console.error('Error al iniciar SignalR:', error));
+        } else {
+            console.warn('SignalR no está disponible. Continuando sin actualizaciones en tiempo real.');
+        }
 
         form.addEventListener('submit', function (e) {
             e.preventDefault();


### PR DESCRIPTION
## Summary
- wrap SignalR connection setup on the home page with an availability check
- keep form submission logic active even when SignalR is missing
- log a warning when SignalR is not present and guard against start errors

## Testing
- dotnet build *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68dfe2a2cf24832db9b17eccf6d78f48