### PR TITLE
Prevent dotnet watch locking on Windows

### DIFF
--- a/ZenkoApp.csproj
+++ b/ZenkoApp.csproj
@@ -5,6 +5,11 @@
     <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
 
+  <PropertyGroup Condition="'$(Configuration)' == 'Debug'">
+    <!-- Evita generar el ejecutable apphost en Debug para que dotnet watch no se bloquee en Windows -->
+    <UseAppHost>false</UseAppHost>
+  </PropertyGroup>
+
   <ItemGroup>
     <PackageReference Include="Dapper" Version="2.1.66" />
     <PackageReference Include="EPPlus" Version="6.0.3" />


### PR DESCRIPTION
## Summary
- disable apphost generation for Debug builds so dotnet watch no longer locks the executable on Windows

## Testing
- dotnet build *(fails: dotnet CLI is not available in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68e3b0155660832d9cf4cfaf8615798a