### PR TITLE
Improve dark mode contrast and mobile experience

### DIFF
--- a/Views/Home/Index.cshtml
+++ b/Views/Home/Index.cshtml
@@ -177,7 +177,7 @@
                             {
                                 <tr>
                                     <td>@tela.Codigo</td>
-                                    <td>@tela.CostoPorMetro.ToString("C")</td>
+                                    <td class="price-value">@tela.CostoPorMetro.ToString("C")</td>
                                 </tr>
                             }
                         </tbody>
@@ -202,7 +202,7 @@
                             {
                                 <tr>
                                     <td>@avio.Codigo</td>
-                                    <td>@avio.CostoUnidad.ToString("C")</td>
+                                    <td class="price-value">@avio.CostoUnidad.ToString("C")</td>
                                 </tr>
                             }
                         </tbody>

--- a/Views/Home/Resultados.cshtml
+++ b/Views/Home/Resultados.cshtml
@@ -57,9 +57,9 @@ else
                                 <tr>
                                     <td>@item.CodigoInsumo</td>
                                     <td>@item.InsumoDescripcion</td>
-                                    <td>@item.CostoInsumo.ToString("C")</td>
+                                    <td class="price-value">@item.CostoInsumo.ToString("C")</td>
                                     <td>@item.Cantidad</td>
-                                    <td>@item.CostoTotal.ToString("C")</td>
+                                    <td class="price-value">@item.CostoTotal.ToString("C")</td>
                                 </tr>
                             }
                         </tbody>
@@ -70,7 +70,7 @@ else
                                     decimal subtotal = grupoVariante.Sum(i => i.CostoTotal);
                                     granTotal += subtotal;
                                 }
-                                <td class="font-weight-bold"><strong>@subtotal.ToString("C")</strong></td>
+                                <td class="font-weight-bold price-value"><strong>@subtotal.ToString("C")</strong></td>
                             </tr>
                         </tfoot>
                     </table>
@@ -82,6 +82,6 @@ else
 
     <hr />
     <div class="text-right">
-        <h3>Gran Total: @granTotal.ToString("C")</h3>
+        <h3 class="price-value">Gran Total: @granTotal.ToString("C")</h3>
     </div>
 }

--- a/Views/Home/SubirConsumos.cshtml
+++ b/Views/Home/SubirConsumos.cshtml
@@ -71,7 +71,7 @@
                                     <div class="fw-semibold">@item.InsumoCodigo</div>
                                     <div class="text-muted">@item.InsumoDescripcion</div>
                                 </td>
-                                <td>@(item.CostoInsumoOperacion.HasValue ? item.CostoInsumoOperacion.Value.ToString("C") : "-")</td>
+                                <td class="price-value">@(item.CostoInsumoOperacion.HasValue ? item.CostoInsumoOperacion.Value.ToString("C") : "-")</td>
                                 <td>@(item.ConsumoPromedio.HasValue ? item.ConsumoPromedio.Value.ToString("N3") : "-")</td>
                                 <td>@(item.ConsumoReal.HasValue ? item.ConsumoReal.Value.ToString("N3") : "-")</td>
                                 <td>@item.CantidadRemitidaTotal.ToString("N3")</td>

--- a/Views/Shared/_Layout.cshtml
+++ b/Views/Shared/_Layout.cshtml
@@ -28,16 +28,16 @@
                 <div class="collapse navbar-collapse" id="navbarNav">
                     <ul class="navbar-nav ms-auto">
                         <li class="nav-item">
-                            <a class="nav-link text-dark" asp-area="" asp-controller="Home" asp-action="Index">Subir Insumos</a>
+                            <a class="nav-link" asp-area="" asp-controller="Home" asp-action="Index">Subir Insumos</a>
                         </li>
                         <li class="nav-item">
-                            <a class="nav-link text-dark" asp-area="" asp-controller="Home" asp-action="SubirProductos">Subir Ficha Técnica</a>
+                            <a class="nav-link" asp-area="" asp-controller="Home" asp-action="SubirProductos">Subir Ficha Técnica</a>
                         </li>
                         <li class="nav-item">
-                            <a class="nav-link text-dark" asp-area="" asp-controller="Home" asp-action="SubirConsumos">Subir Consumos</a>
+                            <a class="nav-link" asp-area="" asp-controller="Home" asp-action="SubirConsumos">Subir Consumos</a>
                         </li>
                         <li class="nav-item">
-                            <a class="nav-link text-dark" asp-area="" asp-controller="Home" asp-action="Resultados">Reporte Final</a>
+                            <a class="nav-link" asp-area="" asp-controller="Home" asp-action="Resultados">Reporte Final</a>
                         </li>
                     </ul>
                     <div class="navbar-utilities">
@@ -49,8 +49,8 @@
                         }
                         else
                         {
-                            <a class="nav-link text-dark" asp-controller="Account" asp-action="Login">Iniciar Sesión</a>
-                            <a class="nav-link text-dark" asp-controller="Account" asp-action="Register">Registrar</a>
+                            <a class="nav-link" asp-controller="Account" asp-action="Login">Iniciar Sesión</a>
+                            <a class="nav-link" asp-controller="Account" asp-action="Register">Registrar</a>
                         }
                         <button id="theme-toggle" class="btn btn-outline-secondary" aria-label="Alternar tema">
                             <span class="theme-label">Modo oscuro</span>

--- a/wwwroot/css/Layout.css
+++ b/wwwroot/css/Layout.css
@@ -125,8 +125,23 @@ main {
   margin: 0;
 }
 
-.navbar-nav .nav-link {
+
+.navbar .container-fluid {
+  gap: 1.25rem;
+}
+
+.navbar-nav .nav-link,
+.navbar-utilities .nav-link,
+.navbar-logout-form .btn-link {
   color: var(--color-nav-link) !important;
+  font-weight: 500;
+  letter-spacing: 0.01em;
+}
+
+[data-theme="dark"] .navbar-nav .nav-link,
+[data-theme="dark"] .navbar-utilities .nav-link,
+[data-theme="dark"] .navbar-logout-form .btn-link {
+  color: var(--color-nav-link-dark) !important;
 }
 
 .navbar-utilities {
@@ -174,6 +189,31 @@ main {
   transform: translateY(-2px);
 }
 
+.navbar-toggler {
+  border: 1px solid var(--color-border);
+  border-radius: 14px;
+  padding: 0.4rem 0.7rem;
+  transition: border-color 0.3s ease, background-color 0.3s ease;
+}
+
+.navbar-toggler-icon {
+  filter: invert(14%) sepia(21%) saturate(900%) hue-rotate(192deg) brightness(90%) contrast(88%);
+  transition: filter 0.3s ease;
+}
+
+.navbar-toggler:focus {
+  box-shadow: 0 0 0 3px rgba(90, 141, 222, 0.25);
+}
+
+[data-theme="dark"] .navbar-toggler {
+  border-color: rgba(148, 163, 184, 0.45);
+  background: rgba(15, 23, 42, 0.55);
+}
+
+[data-theme="dark"] .navbar-toggler-icon {
+  filter: invert(90%) sepia(3%) saturate(223%) hue-rotate(177deg) brightness(108%) contrast(101%);
+}
+
 #theme-toggle {
   border-radius: 999px;
   font-weight: 500;
@@ -184,6 +224,11 @@ main {
   align-items: center;
   gap: 0.5rem;
   overflow: hidden;
+}
+
+#theme-toggle .theme-label {
+  font-weight: 600;
+  color: inherit;
 }
 
 #theme-toggle .theme-icon {
@@ -203,6 +248,10 @@ main {
 
 [data-theme="dark"] #theme-toggle {
   background: rgba(125, 211, 252, 0.12);
+  color: var(--color-nav-link-dark);
+}
+
+[data-theme="dark"] #theme-toggle .theme-label {
   color: var(--color-nav-link-dark);
 }
 
@@ -487,6 +536,66 @@ a:hover {
   .main-container {
     padding: 1rem;
   }
+}
+
+@media (max-width: 991px) {
+  .navbar {
+    padding: 1rem 1.25rem;
+  }
+
+  .navbar .container-fluid {
+    flex-direction: column;
+    align-items: stretch;
+    gap: 1rem;
+  }
+
+  .navbar-brand {
+    align-self: center;
+  }
+
+  .navbar-collapse {
+    width: 100%;
+    margin-top: 0.75rem;
+    padding: 1.5rem 1.25rem;
+    border-radius: 18px;
+    background: var(--color-navbar-bg);
+    box-shadow: 0 18px 40px rgba(15, 23, 42, 0.12);
+  }
+
+  .navbar-nav {
+    align-items: center;
+  }
+
+  .navbar-nav .nav-link {
+    width: 100%;
+    text-align: center;
+    padding: 0.65rem 0.9rem;
+    border-radius: 12px;
+  }
+
+  .navbar-nav .nav-link:hover {
+    background-color: var(--color-nav-link-hover-bg);
+  }
+
+  .navbar-utilities {
+    align-items: center;
+  }
+
+  .navbar-utilities .nav-link,
+  .navbar-logout-form .btn-link,
+  #theme-toggle {
+    max-width: 320px;
+    margin: 0 auto;
+  }
+}
+
+[data-theme="dark"] .navbar-collapse {
+  background: var(--color-navbar-bg-dark);
+  box-shadow: 0 18px 40px rgba(2, 6, 23, 0.65);
+}
+
+[data-theme="dark"] .navbar-nav .nav-link:hover {
+  background-color: var(--color-nav-link-hover-bg-dark);
 }
 
 @media (max-width: 576px) {

--- a/wwwroot/css/site.css
+++ b/wwwroot/css/site.css
@@ -180,6 +180,20 @@
   color: rgba(226, 232, 240, 0.75);
 }
 
+.price-value {
+  font-variant-numeric: tabular-nums;
+  font-weight: 600;
+  color: var(--color-nav-link);
+}
+
+[data-theme="dark"] .price-value {
+  color: #f8fafc;
+}
+
+.price-value strong {
+  color: inherit;
+}
+
 /* Feature cards */
 .section-title {
   margin-bottom: 1.5rem;
@@ -564,6 +578,50 @@
 
   #file-name-display {
     font-size: 0.9rem;
+  }
+}
+
+@media (max-width: 640px) {
+  .hero {
+    text-align: center;
+    gap: 2rem;
+  }
+
+  .hero-content {
+    display: grid;
+    gap: 1.25rem;
+    justify-items: center;
+  }
+
+  .hero p {
+    text-align: center;
+  }
+
+  .stats-grid,
+  .features-grid,
+  .workflow-steps,
+  .results-body {
+    grid-template-columns: 1fr;
+  }
+
+  .section-title {
+    flex-direction: column;
+    align-items: center;
+    text-align: center;
+  }
+
+  .feature-card,
+  .workflow-step {
+    text-align: center;
+  }
+
+  .workflow-step::before {
+    left: 50%;
+    transform: translateX(-50%);
+  }
+
+  .accent-link {
+    justify-content: center;
   }
 }
 


### PR DESCRIPTION
## Summary
- ensure all navigation links inherit themed colors and refine toggler/utility styling for dark mode
- style currency values with a dedicated class so pricing remains legible on dark backgrounds
- add targeted mobile breakpoints that center hero content, stack grids, and tidy the navbar collapse layout

## Testing
- ⚠️ `DOTNET_URLS=http://0.0.0.0:5000 dotnet run` *(fails: dotnet CLI is not available in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68e3ba88247c832d909711d532ebde3c