### PR TITLE
Improve product import validation across multiple Excel files

### DIFF
--- a/Controllers/AccountController.cs
+++ b/Controllers/AccountController.cs
@@ -57,9 +57,13 @@ public class AccountController : Controller
     }
 
     [HttpPost]
+    [ValidateAntiForgeryToken]
     public IActionResult Logout()
     {
-        HttpContext.Session.Clear();
+        if (HttpContext.Session.GetString("Usuario") != null)
+        {
+            HttpContext.Session.Clear();
+        }
         return RedirectToAction("Login");
     }
 }

--- a/Models/BD.cs
+++ b/Models/BD.cs
@@ -129,4 +129,13 @@ public static class BD
             return true;
         }
     }
+
+    public static bool HayInsumosCargados(string connectionString)
+    {
+        using (var db = new SqlConnection(connectionString))
+        {
+            const string sql = "SELECT CASE WHEN EXISTS (SELECT 1 FROM Insumos) THEN 1 ELSE 0 END";
+            return db.QueryFirst<int>(sql) == 1;
+        }
+    }
 }

--- a/Models/ProductoInsumoParseResult.cs
+++ b/Models/ProductoInsumoParseResult.cs
@@ -1,0 +1,12 @@
+using System.Collections.Generic;
+
+namespace Zenko.Models
+{
+    public class ProductoInsumoParseResult
+    {
+        public List<ProductoInsumoExcel> Relaciones { get; } = new List<ProductoInsumoExcel>();
+        public Dictionary<string, string> TodasLasVariantes { get; } = new Dictionary<string, string>(System.StringComparer.OrdinalIgnoreCase);
+        public List<string> Errores { get; } = new List<string>();
+        public List<string> Advertencias { get; } = new List<string>();
+    }
+}

--- a/Views/Account/Login.cshtml
+++ b/Views/Account/Login.cshtml
@@ -1,5 +1,5 @@
 @{
-    ViewData["Title"] = "Login";
+    ViewData["Title"] = "Iniciar Sesión";
 }
 
 <h2>Iniciar Sesión</h2>

--- a/Views/Account/Register.cshtml
+++ b/Views/Account/Register.cshtml
@@ -1,5 +1,5 @@
 @{
-    ViewData["Title"] = "Registrar";
+    ViewData["Title"] = "Crear Cuenta";
 }
 
 <h2>Crear Cuenta</h2>

--- a/Views/Home/Index.cshtml
+++ b/Views/Home/Index.cshtml
@@ -1,6 +1,6 @@
 @using System.Text.Json
 @{
-    ViewData["Title"] = "Cálculo de Costos de Producción";
+    ViewData["Title"] = "Subir Insumos";
     var procesosIniciales = ViewData["Procesos"] as List<Zenko.Models.QueuedProcessViewModel> ?? new List<Zenko.Models.QueuedProcessViewModel>();
     var procesosInicialesJson = JsonSerializer.Serialize(procesosIniciales);
 }

--- a/Views/Home/SubirConsumos.cshtml
+++ b/Views/Home/SubirConsumos.cshtml
@@ -1,6 +1,6 @@
 @model Zenko.Models.ConsumoResultadoViewModel
 @{
-    ViewData["Title"] = "Subir Archivos de Consumos";
+    ViewData["Title"] = "Subir Consumos";
 }
 
 <div class="card">
@@ -130,19 +130,24 @@
 
 @section Scripts {
     <script>
-        document.getElementById('archivosConsumo').addEventListener('change', function (e) {
-            const fileInput = e.target;
-            const display = document.getElementById('consumo-file-name');
-
-            if (fileInput.files && fileInput.files.length > 0) {
-                if (fileInput.files.length === 1) {
-                    display.textContent = 'Archivo seleccionado: ' + fileInput.files[0].name;
-                } else {
-                    display.textContent = fileInput.files.length + ' archivos seleccionados';
-                }
-            } else {
-                display.textContent = '';
+        (function () {
+            const fileInput = document.getElementById('archivosConsumo');
+            if (!fileInput) {
+                return;
             }
-        });
+            fileInput.addEventListener('change', function (e) {
+                const display = document.getElementById('consumo-file-name');
+
+                if (fileInput.files && fileInput.files.length > 0) {
+                    if (fileInput.files.length === 1) {
+                        display.textContent = 'Archivo seleccionado: ' + fileInput.files[0].name;
+                    } else {
+                        display.textContent = fileInput.files.length + ' archivos seleccionados';
+                    }
+                } else {
+                    display.textContent = '';
+                }
+            });
+        })();
     </script>
 }

--- a/Views/Home/SubirProductos.cshtml
+++ b/Views/Home/SubirProductos.cshtml
@@ -1,28 +1,47 @@
-@{
-    ViewData["Title"] = "Subir Archivos de Productos";
+@{ 
+    ViewData["Title"] = "Subir Fichas Técnicas";
+    var puedeCargarProductos = ViewData["PuedeCargarProductos"] as bool? ?? true;
+    var advertenciaInsumos = ViewData["AdvertenciaInsumos"] as string;
+    var advertenciasArchivos = ViewData["AdvertenciasArchivos"] as System.Collections.Generic.IEnumerable<string>;
 }
 
 <div class="card">
     <div class="card-header">
-        Cargar Archivos de Productos
+        Cargar Fichas Técnicas
     </div>
     <div class="card-body">
+        @if (!string.IsNullOrWhiteSpace(advertenciaInsumos))
+        {
+            <div class="alert alert-warning" role="alert">
+                @Html.Raw(advertenciaInsumos)
+            </div>
+        }
+        if (advertenciasArchivos != null)
+        {
+            foreach (var advertencia in advertenciasArchivos)
+            {
+                if (!string.IsNullOrWhiteSpace(advertencia))
+                {
+                    <div class="alert alert-info" role="alert">@advertencia</div>
+                }
+            }
+        }
         <div asp-validation-summary="All" class="text-danger"></div>
         <form asp-action="SubirProductos" method="post" enctype="multipart/form-data">
-            <div class="file-upload-wrapper">
+            <div class="file-upload-wrapper@(puedeCargarProductos ? string.Empty : " is-disabled")">
                 <div class="file-upload-icon">
                     <svg xmlns="http://www.w3.org/2000/svg" width="48" height="48" fill="currentColor" class="bi bi-box-seam" viewBox="0 0 16 16">
                         <path d="M8.186 1.113a.5.5 0 0 0-.372 0L1.846 3.5l2.404.961L8 2.596l3.75 1.865 2.404-.961L8.186 1.113zM14.5 3.5l-2.404.961L8 6.404 4.25 4.46l-2.404-.961L1.5 3.5v9l6.5 3 6.5-3v-9zM1 3.76l7 2.8v8.64l-7-2.8V3.76zm14 0v8.64l-7 2.8v-8.64l7-2.8z"/>
                     </svg>
                 </div>
-                <label for="archivosExcel" class="file-upload-label">
-                    Arrastra tus archivos de productos aquí o haz clic para seleccionar
+                <label for="archivosExcel" class="file-upload-label@(puedeCargarProductos ? string.Empty : " disabled-label")"@(!puedeCargarProductos ? " aria-disabled=\"true\"" : string.Empty)>
+                    Arrastra tus fichas técnicas en Excel aquí o haz clic para seleccionar
                 </label>
-                <input type="file" name="archivosExcel" id="archivosExcel" multiple accept=".xls,.xlsx" />
+                <input type="file" name="archivosExcel" id="archivosExcel" multiple accept=".xls,.xlsx" @(!puedeCargarProductos ? "disabled=\"disabled\"" : string.Empty) />
             </div>
             <div id="file-name-display" class="text-center"></div>
             <div class="btn-container">
-                <button type="submit" class="btn btn-primary">Procesar Productos</button>
+                <button type="submit" class="btn btn-primary" @(!puedeCargarProductos ? "disabled=\"disabled\"" : string.Empty)>Procesar Fichas Técnicas</button>
             </div>
         </form>
     </div>
@@ -37,19 +56,24 @@
 
 @section Scripts {
     <script>
-        document.getElementById('archivosExcel').addEventListener('change', function(e) {
-            const fileInput = e.target;
-            const display = document.getElementById('file-name-display');
-
-            if (fileInput.files && fileInput.files.length > 0) {
-                if (fileInput.files.length === 1) {
-                    display.textContent = 'Archivo seleccionado: ' + fileInput.files[0].name;
-                } else {
-                    display.textContent = fileInput.files.length + ' archivos seleccionados';
-                }
-            } else {
-                display.textContent = '';
+        (function () {
+            const fileInput = document.getElementById('archivosExcel');
+            if (!fileInput) {
+                return;
             }
-        });
+            fileInput.addEventListener('change', function (e) {
+                const display = document.getElementById('file-name-display');
+
+                if (fileInput.files && fileInput.files.length > 0) {
+                    if (fileInput.files.length === 1) {
+                        display.textContent = 'Archivo seleccionado: ' + fileInput.files[0].name;
+                    } else {
+                        display.textContent = fileInput.files.length + ' archivos seleccionados';
+                    }
+                } else {
+                    display.textContent = '';
+                }
+            });
+        })();
     </script>
 }

--- a/Views/Shared/_Layout.cshtml
+++ b/Views/Shared/_Layout.cshtml
@@ -31,7 +31,7 @@
                             <a class="nav-link" asp-area="" asp-controller="Home" asp-action="Index">Subir Insumos</a>
                         </li>
                         <li class="nav-item">
-                            <a class="nav-link" asp-area="" asp-controller="Home" asp-action="SubirProductos">Subir Ficha Técnica</a>
+                            <a class="nav-link" asp-area="" asp-controller="Home" asp-action="SubirProductos">Subir Fichas Técnicas</a>
                         </li>
                         <li class="nav-item">
                             <a class="nav-link" asp-area="" asp-controller="Home" asp-action="SubirConsumos">Subir Consumos</a>
@@ -44,6 +44,7 @@
                         @if (Context.Session.GetString("Usuario") != null)
                         {
                             <form asp-controller="Account" asp-action="Logout" method="post" class="navbar-logout-form">
+                                @Html.AntiForgeryToken()
                                 <button type="submit" class="btn btn-link">Cerrar sesión (@Context.Session.GetString("Usuario"))</button>
                             </form>
                         }

--- a/wwwroot/css/Layout.css
+++ b/wwwroot/css/Layout.css
@@ -75,6 +75,16 @@ body {
   transition: background-color 0.4s ease, color 0.4s ease;
 }
 
+[data-theme="dark"] h1,
+[data-theme="dark"] h2,
+[data-theme="dark"] h3,
+[data-theme="dark"] h4,
+[data-theme="dark"] h5,
+[data-theme="dark"] h6,
+[data-theme="dark"] .brand-name {
+  color: var(--color-texto-dark);
+}
+
 h1, h2, h3, .brand-name {
   font-family: 'Clash Display', 'Montserrat', sans-serif;
   letter-spacing: -0.01em;

--- a/wwwroot/css/site.css
+++ b/wwwroot/css/site.css
@@ -394,6 +394,12 @@
   transform: translateY(-4px);
 }
 
+.file-upload-wrapper.is-disabled {
+  opacity: 0.55;
+  cursor: not-allowed;
+  pointer-events: none;
+}
+
 .file-upload-icon {
   color: var(--color-brand-highlight);
   margin-bottom: 1.25rem;
@@ -404,6 +410,10 @@
   font-weight: 600;
   color: var(--color-nav-link);
   font-size: 1.1rem;
+}
+
+.file-upload-label.disabled-label {
+  color: rgba(100, 116, 139, 0.9);
 }
 
 .file-upload-wrapper input[type="file"] {
@@ -675,4 +685,30 @@
 
 [data-theme="dark"] .workflow-step::before {
   box-shadow: 0 12px 24px rgba(96, 165, 250, 0.45);
+}
+
+[data-theme="dark"] .alert {
+  background-color: rgba(15, 23, 42, 0.75);
+  border-color: rgba(148, 163, 184, 0.45);
+  color: rgba(226, 232, 240, 0.92);
+}
+
+[data-theme="dark"] .alert-warning {
+  background-color: rgba(217, 119, 6, 0.18);
+  border-color: rgba(251, 191, 36, 0.45);
+  color: #fcd34d;
+}
+
+[data-theme="dark"] .alert-success {
+  background-color: rgba(22, 163, 74, 0.22);
+  border-color: rgba(74, 222, 128, 0.45);
+  color: #bbf7d0;
+}
+
+[data-theme="dark"] .text-danger {
+  color: #fca5a5 !important;
+}
+
+[data-theme="dark"] .text-muted {
+  color: rgba(203, 213, 225, 0.75) !important;
 }


### PR DESCRIPTION
## Summary
- capture file-level errors and warnings when reading ficha técnica excels so multi-file uploads continue processing valid data
- show parsing warnings alongside the form and keep strong validation in the controller before touching the database
- add a dedicated parse-result model to share structured feedback between the Excel service and MVC layer

## Testing
- `dotnet build` *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68ecf4539784832d9543d15d080c2bfc